### PR TITLE
fix(ci): correct build paths in docker container

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -14,16 +14,14 @@ runs:
     - name: Build halos package
       shell: bash
       run: |
-        cd halos
-        docker compose -f ../docker/docker-compose.debtools.yml run --rm debtools \
-          bash -c "dpkg-buildpackage -b -uc -us && mv ../*.deb ../*.buildinfo ../*.changes ./ 2>/dev/null || true"
+        docker compose -f docker/docker-compose.debtools.yml run --rm debtools \
+          bash -c "cd halos && dpkg-buildpackage -b -uc -us && mv ../*.deb ../*.buildinfo ../*.changes ./"
 
     - name: Build halos-marine package
       shell: bash
       run: |
-        cd halos-marine
-        docker compose -f ../docker/docker-compose.debtools.yml run --rm debtools \
-          bash -c "dpkg-buildpackage -b -uc -us && mv ../*.deb ../*.buildinfo ../*.changes ./ 2>/dev/null || true"
+        docker compose -f docker/docker-compose.debtools.yml run --rm debtools \
+          bash -c "cd halos-marine && dpkg-buildpackage -b -uc -us && mv ../*.deb ../*.buildinfo ../*.changes ./"
 
     - name: Move packages to root
       shell: bash


### PR DESCRIPTION
## Summary
- Fix dpkg-buildpackage failing with "cannot open file debian/changelog"
- The `cd` to package directories must happen inside the container, not on the host

The docker volume mounts the repo root at `/workspace`. When running from `cd halos` on the host, the docker compose path is resolved but the container's working directory is still `/workspace` (repo root), not `/workspace/halos`.

## Test plan
- [ ] Verify PR checks pass (both packages build successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)