### PR TITLE
fix(ci): add --repo flag to gh release commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           PRERELEASE_TAG="${{ steps.version.outputs.prerelease_tag }}"
 
           echo "📥 Downloading .deb from pre-release $PRERELEASE_TAG"
-          gh release download "$PRERELEASE_TAG" --pattern "*.deb"
+          gh release download "$PRERELEASE_TAG" --repo ${{ github.repository }} --pattern "*.deb"
 
           if ! ls *.deb 1> /dev/null 2>&1; then
             echo "❌ Error: No .deb files downloaded from pre-release"
@@ -87,7 +87,7 @@ jobs:
           STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
 
           echo "📤 Uploading .deb to stable release $STABLE_TAG"
-          gh release upload "$STABLE_TAG" *.deb --clobber
+          gh release upload "$STABLE_TAG" --repo ${{ github.repository }} *.deb --clobber
 
           echo "✅ Assets uploaded successfully"
         env:


### PR DESCRIPTION
## Summary
Fix release workflow failing with `fatal: not a git repository`

The `gh release download` and `gh release upload` commands require `--repo` flag when not running in a git repository context.

## Test plan
- [ ] Re-run the release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)