### PR TITLE
feat(halos): add docker and cockpit-dockermanager dependencies

### DIFF
--- a/halos/debian/control
+++ b/halos/debian/control
@@ -14,7 +14,11 @@ Depends: ${misc:Depends},
          cockpit-networkmanager,
          cockpit-storaged,
          cockpit-apt,
-         cockpit-branding-halos
+         cockpit-dockermanager,
+         cockpit-branding-halos,
+         docker.io,
+         docker-compose,
+         docker-cli
 Description: Base system metapackage for HaLOS
  This metapackage installs the base HaLOS system, providing web-based
  Raspberry Pi management through Cockpit.


### PR DESCRIPTION
## Summary

Add Docker container support to the halos base metapackage:
- `cockpit-dockermanager` - Container management UI for Cockpit
- `docker.io` - Docker container runtime
- `docker-compose` - Multi-container orchestration
- `docker-cli` - Docker command-line interface

## Test plan

- [ ] Package builds successfully
- [ ] Dependencies resolve correctly on target system
- [ ] Docker and cockpit-dockermanager work after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)