### PR TITLE
refactor(ci): use native dpkg instead of Docker for CI builds

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y dpkg-dev debhelper
+        sudo apt-get install -y dpkg-dev debhelper build-essential
 
     - name: Build halos package
       shell: bash


### PR DESCRIPTION
## Summary

Simplify CI builds by using native Ubuntu runner tools instead of Docker.

**Rationale:** Metapackages contain only `debian/control` files with dependency declarations - no compiled code, no binaries, nothing that depends on the build environment. The only requirement is `dpkg-dev` and `debhelper`, which are available natively on the Ubuntu runner.

**Changes:**
- CI build action now installs `dpkg-dev` and `debhelper` directly
- Runs `dpkg-buildpackage` without Docker container overhead
- Docker setup retained for local development (`./run` commands) where developers on macOS need containerized dpkg tools

**Benefits:**
- Faster CI builds (no Docker image build/pull)
- Simpler CI configuration
- Reduced complexity

## Test plan

- [ ] CI builds both packages successfully
- [ ] Generated .deb files are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)