### PR TITLE
fix(deps): update package names to use new prefixes

### DIFF
--- a/halos-marine/debian/control
+++ b/halos-marine/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: ${misc:Depends},
          halos (>= ${binary:Version}),
          marine-container-store,
-         signalk-server-container
+         marine-signalk-server-container
 Description: HaLOS marine system metapackage
  This metapackage extends the base HaLOS system with marine navigation
  and monitoring software.

--- a/halos/debian/control
+++ b/halos/debian/control
@@ -18,7 +18,8 @@ Depends: ${misc:Depends},
          cockpit-branding-halos,
          docker.io,
          docker-compose,
-         docker-cli
+         docker-cli,
+         halos-homarr-container
 Description: Base system metapackage for HaLOS
  This metapackage installs the base HaLOS system, providing web-based
  Raspberry Pi management through Cockpit.
@@ -28,6 +29,7 @@ Description: Base system metapackage for HaLOS
   * Network configuration through cockpit-networkmanager
   * Storage management through cockpit-storaged
   * Package management through cockpit-apt
+  * Homarr dashboard for container app access
   * Custom HaLOS branding
  .
  HaLOS is a Debian-based operating system designed for easy management


### PR DESCRIPTION
## Summary

Update container package names to match the new naming convention with prefixes:

- **halos**: Add `halos-homarr-container` dependency (core dashboard)
- **halos-marine**: Change `signalk-server-container` to `marine-signalk-server-container`

## Background

Container packages now use prefixes (`halos-`, `marine-`, `casaos-`) as implemented in container-packaging-tools. The metapackages need to reference the correct prefixed package names.

## Changes

| Metapackage | Old Dependency | New Dependency |
|-------------|----------------|----------------|
| halos | (none) | halos-homarr-container |
| halos-marine | signalk-server-container | marine-signalk-server-container |

## Test plan

- [ ] Verify CI passes
- [ ] After container packages are published, verify metapackage installation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)