### PR TITLE
fix(deps): add homarr-container-adapter and homarr-branding-halos

### DIFF
--- a/halos/debian/changelog
+++ b/halos/debian/changelog
@@ -1,3 +1,10 @@
+halos (0.2.0-1) unstable; urgency=medium
+
+  * Add homarr-container-adapter dependency for automatic first-boot setup
+  * Add homarr-branding-halos dependency for dashboard branding
+
+ -- Hat Labs <info@hatlabs.fi>  Sun, 15 Dec 2025 13:10:00 +0200
+
 halos (0.1.0-1) unstable; urgency=medium
 
   * Initial release.

--- a/halos/debian/control
+++ b/halos/debian/control
@@ -19,7 +19,9 @@ Depends: ${misc:Depends},
          docker.io,
          docker-compose,
          docker-cli,
-         halos-homarr-container
+         halos-homarr-container,
+         homarr-container-adapter,
+         homarr-branding-halos
 Description: Base system metapackage for HaLOS
  This metapackage installs the base HaLOS system, providing web-based
  Raspberry Pi management through Cockpit.
@@ -30,6 +32,7 @@ Description: Base system metapackage for HaLOS
   * Storage management through cockpit-storaged
   * Package management through cockpit-apt
   * Homarr dashboard for container app access
+  * Automatic container discovery and dashboard integration
   * Custom HaLOS branding
  .
  HaLOS is a Debian-based operating system designed for easy management


### PR DESCRIPTION
## Summary
- Add `homarr-container-adapter` dependency for automatic first-boot setup
- Add `homarr-branding-halos` dependency for dashboard branding configuration

Without these dependencies, users see the stock Homarr onboarding wizard instead of a pre-configured dashboard with HaLOS branding.

## Test plan
- [ ] Build updated halos metapackage
- [ ] Install on test system with fresh Homarr container
- [ ] Verify Homarr starts with HaLOS branding (no onboarding wizard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)