### PR TITLE
refactor: update homarr-branding-halos refs to halos-homarr-branding

### DIFF
--- a/halos/debian/changelog
+++ b/halos/debian/changelog
@@ -1,7 +1,7 @@
 halos (0.2.0-1) unstable; urgency=medium
 
   * Add homarr-container-adapter dependency for automatic first-boot setup
-  * Add homarr-branding-halos dependency for dashboard branding
+  * Add halos-homarr-branding dependency for dashboard branding
 
  -- Hat Labs <info@hatlabs.fi>  Sun, 15 Dec 2025 13:10:00 +0200
 

--- a/halos/debian/control
+++ b/halos/debian/control
@@ -21,7 +21,7 @@ Depends: ${misc:Depends},
          docker-cli,
          halos-homarr-container,
          homarr-container-adapter,
-         homarr-branding-halos
+         halos-homarr-branding
 Description: Base system metapackage for HaLOS
  This metapackage installs the base HaLOS system, providing web-based
  Raspberry Pi management through Cockpit.


### PR DESCRIPTION
## Summary
Update dependency name following the package rename from `homarr-branding-halos` to `halos-homarr-branding` for consistent naming convention (halos- prefix for HaLOS packages).

## Changes
- `halos/debian/control` - Updated dependency from `homarr-branding-halos` to `halos-homarr-branding`
- `halos/debian/changelog` - Updated changelog entry to reflect new package name

## Related PRs
This is part of a coordinated rename across multiple repositories:
- hatlabs/halos-homarr-branding (repo renamed, PR merged)
- hatlabs/halos-distro#50
- hatlabs/halos-core-containers#10
- hatlabs/homarr-container-adapter#6

## Test plan
- [ ] PR checks pass (package builds successfully)
- [ ] Verify halos metapackage installs with new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)