### PR TITLE
feat: add bumpversion command with dch for proper changelog dates

### DIFF
--- a/.github/scripts/check-changelog-edits.sh
+++ b/.github/scripts/check-changelog-edits.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook to prevent direct debian/changelog edits.
+# Changelog updates must go through ./run bumpversion which uses dch
+# to ensure proper RFC 2822 date formatting.
+#
+# Bypass: SKIP_CHANGELOG_CHECK=1 git commit ...
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Allow bypass for ./run bumpversion (via env var)
+if [[ "${SKIP_CHANGELOG_CHECK:-}" == "1" ]]; then
+    exit 0
+fi
+
+# Check if any debian/changelog files are staged
+CHANGELOG_FILES=$(git diff --cached --name-only | grep -E 'debian/changelog$' || true)
+
+if [[ -n "$CHANGELOG_FILES" ]]; then
+    echo "ERROR: Direct debian/changelog edits are not allowed."
+    echo ""
+    echo "Staged changelog files:"
+    echo "$CHANGELOG_FILES" | sed 's/^/  /'
+    echo ""
+    echo "Why: Manual changelog edits often have RFC 2822 date formatting errors"
+    echo "(wrong weekday for date). The dch tool handles this correctly."
+    echo ""
+    echo "Solution: Use './run bumpversion [patch|minor|major]' which:"
+    echo "  1. Updates VERSION file"
+    echo "  2. Uses dch to update debian/changelog with correct dates"
+    echo "  3. Commits the changes"
+    echo ""
+    echo "If you need to bypass this check (e.g., fixing a changelog):"
+    echo "  SKIP_CHANGELOG_CHECK=1 git commit ..."
+    echo ""
+    exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # HaLOS Metapackages - Agentic Coding Guide
 
-**LAST MODIFIED**: 2025-11-21
+**LAST MODIFIED**: 2026-01-02
 
 ## 🎯 For Agentic Coding: Use the HaLOS Workspace
 
@@ -41,3 +41,44 @@ halos-metapackages/
 **Branch Workflow**: Never push to main - use feature branches and PRs.
 
 See `halos-distro/docs/DEVELOPMENT_WORKFLOW.md` for detailed workflows.
+
+## Version Management
+
+**CRITICAL: Never edit debian/changelog files directly.**
+
+Changelogs must be updated using `./run bumpversion` which uses the `dch` tool
+to ensure proper RFC 2822 date formatting. Direct edits cause weekday/date
+mismatches that break Debian tools.
+
+### Bumping Versions
+
+```bash
+# Bump patch version (0.2.4 -> 0.2.5)
+./run bumpversion patch
+
+# Bump minor version (0.2.4 -> 0.3.0)
+./run bumpversion minor "Add new feature"
+
+# Bump major version (0.2.4 -> 1.0.0)
+./run bumpversion major "Breaking changes"
+
+# Push the automatically created commit
+git push
+```
+
+The command:
+1. Updates the VERSION file
+2. Updates both halos/debian/changelog and halos-marine/debian/changelog using dch
+3. Commits all changes
+
+### Pre-commit Hooks
+
+Install hooks after cloning:
+```bash
+./run install-hooks
+```
+
+The hooks prevent direct changelog edits. If you need to bypass (e.g., fixing an existing error):
+```bash
+SKIP_CHANGELOG_CHECK=1 git commit ...
+```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+# Lefthook configuration for halos-metapackages
+# Install with: ./run install-hooks
+
+pre-commit:
+  parallel: true
+  commands:
+    check-changelog:
+      run: .github/scripts/check-changelog-edits.sh
+      fail_text: "Direct debian/changelog edits are not allowed. Use './run bumpversion' instead."

--- a/run
+++ b/run
@@ -96,6 +96,115 @@ function clean-debtools {
 }
 
 ################################################################################
+# Version Management Commands
+
+function bumpversion {
+  #@ Bump version using dch (patch|minor|major) [message]
+  #@ Category: Version
+  local BUMP_TYPE="${1:-}"
+  local MESSAGE="${2:-Version bump}"
+
+  if [[ -z "$BUMP_TYPE" ]]; then
+    echo "Error: version bump type required"
+    echo "Usage: ./run bumpversion [patch|minor|major] [message]"
+    exit 1
+  fi
+
+  if [[ ! "$BUMP_TYPE" =~ ^(patch|minor|major)$ ]]; then
+    echo "Error: invalid bump type '$BUMP_TYPE'"
+    echo "Usage: ./run bumpversion [patch|minor|major] [message]"
+    exit 1
+  fi
+
+  # Check for clean working directory
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: working directory not clean"
+    echo "Commit or stash changes before bumping version"
+    exit 1
+  fi
+
+  # Read current version
+  local CURRENT_VERSION
+  CURRENT_VERSION=$(cat VERSION)
+  echo "Current version: $CURRENT_VERSION"
+
+  # Calculate new version
+  local IFS='.'
+  read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+  local MAJOR="${VERSION_PARTS[0]}"
+  local MINOR="${VERSION_PARTS[1]}"
+  local PATCH="${VERSION_PARTS[2]}"
+
+  case "$BUMP_TYPE" in
+    major)
+      MAJOR=$((MAJOR + 1))
+      MINOR=0
+      PATCH=0
+      ;;
+    minor)
+      MINOR=$((MINOR + 1))
+      PATCH=0
+      ;;
+    patch)
+      PATCH=$((PATCH + 1))
+      ;;
+  esac
+
+  local NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+  echo "New version: $NEW_VERSION"
+
+  # Update VERSION file
+  echo "$NEW_VERSION" > VERSION
+
+  # Update both changelogs using dch in debtools container
+  echo "Updating changelogs using dch..."
+
+  debtools bash -c "
+    export DEBEMAIL='info@hatlabs.fi'
+    export DEBFULLNAME='Hat Labs'
+
+    cd halos && dch --newversion '${NEW_VERSION}-1' --distribution unstable '$MESSAGE'
+    cd ../halos-marine && dch --newversion '${NEW_VERSION}-1' --distribution unstable '$MESSAGE'
+  "
+
+  echo "Committing changes..."
+
+  # Commit the changes (bypass changelog check since we used dch)
+  git add VERSION halos/debian/changelog halos-marine/debian/changelog
+  SKIP_CHANGELOG_CHECK=1 git commit -m "chore: bump version to ${NEW_VERSION}
+
+${MESSAGE}"
+
+  echo ""
+  echo "✅ Version bumped to $NEW_VERSION"
+  echo "Push with: git push"
+}
+
+################################################################################
+# Development Commands
+
+function install-hooks {
+  #@ Install pre-commit hooks using lefthook
+  #@ Category: Development
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook install
+  echo "✅ Pre-commit hooks installed"
+}
+
+function run-hooks {
+  #@ Run pre-commit hooks manually
+  #@ Category: Development
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook run pre-commit
+}
+
+################################################################################
 # Utility Commands
 
 function clean {


### PR DESCRIPTION
## Summary

- Adds `./run bumpversion [patch|minor|major] [message]` command that uses `dch` in debtools container to update debian/changelog with correct RFC 2822 date formatting
- Adds lefthook pre-commit hook to prevent direct changelog edits
- Adds `install-hooks` and `run-hooks` commands
- Updates AGENTS.md with Version Management documentation

## Why

Claude Code frequently edits debian/changelog files directly, causing RFC 2822 date formatting errors (wrong weekday). The `dch` tool handles date formatting correctly.

## How It Works

1. `./run bumpversion patch` - Updates VERSION file
2. Runs `dch` in debtools container for both halos and halos-marine changelogs
3. Commits all changes with `SKIP_CHANGELOG_CHECK=1` to bypass the hook

The lefthook hook prevents direct changelog edits, with bypass available via:
```bash
SKIP_CHANGELOG_CHECK=1 git commit ...
```

## Test Plan

- [ ] Install hooks: `./run install-hooks`
- [ ] Verify hook blocks direct changelog edits
- [ ] Test bumpversion command: `./run bumpversion patch "Test bump"`
- [ ] Verify changelog has correct RFC 2822 date format

🤖 Generated with [Claude Code](https://claude.com/claude-code)