### PR TITLE
feat(halos): depend on halos-core-containers

### DIFF
--- a/halos/debian/control
+++ b/halos/debian/control
@@ -22,7 +22,7 @@ Depends: ${misc:Depends},
          docker.io,
          docker-compose,
          docker-cli,
-         halos-homarr-container,
+         halos-core-containers,
          homarr-container-adapter,
          halos-homarr-branding,
          halos-mdns-publisher


### PR DESCRIPTION
## Summary

- Replace `halos-homarr-container` dependency with `halos-core-containers`

The `halos-core-containers` package consolidates traefik, authelia, and homarr into a single package with unified docker-compose orchestration. This provides:
- Native Docker `depends_on` for proper startup ordering
- Single systemd service instead of three
- Simplified deployment and debugging

## Test plan

- [ ] Install halos metapackage on test device
- [ ] Verify halos-core-containers is pulled in as dependency
- [ ] Verify all three services (traefik, authelia, homarr) start correctly
- [ ] Verify web UI is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)