### PR TITLE
docs(agents): point version-bump guidance at canonical policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,4 +65,4 @@ git push
 
 Requires `bump2version` installed (`pip install bump2version`).
 
-**CI Enforcement**: PRs that change package-affecting files must include a VERSION bump or CI will fail. Changes to docs, tests, CI config, and dev tooling are automatically excluded.
+**CI Enforcement**: VERSION bumps are per release cycle, not per PR — CI fails only on the PR that opens a new cycle (when VERSION still matches the latest stable release and the PR touches package-affecting files); later PRs in the same cycle must not bump. See the workspace `AGENTS.md` version-bump policy for the full decision procedure.


### PR DESCRIPTION
Replaces the per-PR enforcement line (which read as "any package-affecting PR must bump VERSION") with a one-line per-cycle summary that points at the canonical decision procedure in the workspace `AGENTS.md` (halos-org/halos). Behavior unchanged — matches what CI already enforces. Docs only.

Closes #44.