### PR TITLE
docs: add top-level LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+MIT License
+
+Copyright (c) 2025-2026 Hat Labs Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------
+
+This file is the GitHub/casual-browser convention. This repository builds
+several metapackages, each with its own canonical, machine-readable license
+record in its per-package debian/copyright file (e.g. halos/debian/copyright,
+halos-marine/debian/copyright). Consult those for the per-package, per-file
+license breakdown in the Debian copyright format.


### PR DESCRIPTION
## Why

This repository declared its license only in per-package `debian/copyright` files, so GitHub-side license auto-detection reported "No license" and third-party tooling that scans for a root `LICENSE`/`LICENSE.md`/`COPYING` saw nothing. Adding a top-level `LICENSE` satisfies the GitHub/casual-browser convention while the per-package `debian/copyright` files remain the canonical machine-readable record.

## What

- Add a root `LICENSE` with the MIT license text matching the per-package `debian/copyright` files (Copyright (c) 2025-2026 Hat Labs Ltd — the per-package files span 2025 and 2026).
- Includes a note pointing readers to the per-package `debian/copyright` files for the per-file machine-readable breakdown.

Documentation/convention only — no code changes, no package-affecting files, so no `VERSION` bump or `debian/changelog` edit.

Closes #42